### PR TITLE
Use a public URL for the submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "website/themes/roxo"]
 	path = website/themes/roxo
-	url = git@github.com:StaticMania/roxo-hugo.git
+	url = https://github.com/StaticMania/roxo-hugo.git


### PR DESCRIPTION
Since we want to build the website without a ssh key (think Openshift), we need a public https url.