### PR TITLE
Fix the base url for the website

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,4 +1,4 @@
-baseURL       = "http://example.org/"
+baseURL       = "/"
 languageCode  = "en-us"
 title         = "Gender Transition Resources Guide"
 theme         = "roxo"


### PR DESCRIPTION
By default, this will fetch CSS and others from example.org,
who return 404 errors and CSS is not applied