### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM registry.fedoraproject.org/fedora:33
+
+RUN dnf install -y nginx hugo rubygem-asciidoctor-pdf && dnf clean all -y
+
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY . /var/www/html/
+
+WORKDIR /var/www/html/
+
+RUN ./publish.sh
+RUN cd website && hugo
+
+EXPOSE 8080
+
+USER 1000
+
+ENTRYPOINT ["/usr/sbin/nginx"]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,32 @@
+worker_processes  1;
+
+daemon off;
+pid /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    error_log /dev/null;
+    access_log /dev/null;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+    gzip on;
+
+    server {
+        listen 8080;
+        port_in_redirect off;
+        location / {
+            root /var/www/html/website/public/;
+            # equivalent to DirectorySlash in apache
+            rewrite ^([^.]*[^/])$ $1/ permanent;
+        }
+    }
+}
+


### PR DESCRIPTION
The Dockerfile can be used to deploy the website on Openshift (tested with a Online Dedicated cluster), or to run it locally. 